### PR TITLE
fix wasm file name in lib folder

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,4 +3,4 @@
 cargo build --target wasm32-unknown-emscripten --release
 mkdir -p lib
 cp target/wasm32-unknown-emscripten/release/mozjpeg-wasm.js lib/mozjpeg-wasm.js
-cp target/wasm32-unknown-emscripten/release/mozjpeg_wasm.wasm lib/mozjpeg-wasm.wasm
+cp target/wasm32-unknown-emscripten/release/mozjpeg_wasm.wasm lib/mozjpeg_wasm.wasm


### PR DESCRIPTION
Hey,

thanks for this awesome work.
Seems there is typo when you copy wasm file from `target` folder to `lib`